### PR TITLE
Use Gradle toolchains

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           distribution: zulu
           java-version: 8
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 17
       - shell: bash
         env:
           GRADLE_PLUGIN_PUBLISH_KEY: ${{ secrets.GRADLE_PLUGIN_PUBLISH_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## [Unreleased]
 
-## [3.0.0] 2023-02-28
+## [3.0.0] 2023-03-07
 
 ### Changed
 
 - Project now uses Gradle's Kotlin based DSL. Users are still able to use Groovy in their projects. ([#55](https://github.com/heroku/heroku-gradle/pull/55))
 - Ported functional tests from Groovy to Java. ([#55](https://github.com/heroku/heroku-gradle/pull/55))
-- Updated `com.heroku.sdk:heroku-deploy` to version `3.0.6`. ([#55](https://github.com/heroku/heroku-gradle/pull/55))
+- Updated `com.heroku.sdk:heroku-deploy` to version `3.0.7`. ([#58](https://github.com/heroku/heroku-gradle/pull/58))
 
 ### Added
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -7,8 +7,9 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 repositories {
@@ -41,6 +42,12 @@ gradlePlugin {
 val functionalTestSourceSet = sourceSets.create("functionalTest") {
 }
 
+tasks.named<JavaCompile>(functionalTestSourceSet.getCompileTaskName("java")) {
+    javaCompiler.set(javaToolchains.compilerFor {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    })
+}
+
 configurations["functionalTestImplementation"].extendsFrom(configurations["testImplementation"])
 
 val functionalTest by tasks.registering(Test::class) {
@@ -48,10 +55,9 @@ val functionalTest by tasks.registering(Test::class) {
     classpath = functionalTestSourceSet.runtimeClasspath
     useJUnitPlatform()
 
-    java {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
+    javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    })
 }
 
 gradlePlugin.testSourceSets(functionalTestSourceSet)


### PR DESCRIPTION
This PR attempts to fix the plugin release issues WRT Java versions by using Gradle's toolchain feature.

It also updates the CHANGELOG since the `3.0.0` never went out.

Ref: GUS-W-11967508